### PR TITLE
add initial implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,33 @@
 # MuchNotGiven
 
-Add "not given" default values to your objects.
+Add "not given" default values to your objects. This allows you to safely detect whether a method has been given argument values or not.
 
 ## Usage
 
-TODO: Write code samples and usage instructions here
+```ruby
+module MyNamespace
+  include MuchNotGiven
+end
+
+MyNamespace.not_given                           # => MyNamespace.not_given
+"some value" == MyNamespace.not_given           # => false
+MyNamespace.not_given?("some value")            # => false
+MyNamespace.not_given?(MyNamespace.not_given?)  # => true
+MyNamespace.given?("some value")                # => true
+MyNamespace.given?(MyNamespace.not_given?)      # => false
+
+def my_method(value = MyNamespace.not_given)
+  if MyNamespace.given?(value)
+    # do something with the given value
+  end
+end
+
+def my_method(arg_value = MyNamespace.not_given)
+  value = MyNamespace.given?(value) ? value : "some default value"
+
+  # do something with the optionally defaulted value
+end
+```
 
 ## Installation
 

--- a/lib/much-not-given.rb
+++ b/lib/much-not-given.rb
@@ -1,4 +1,51 @@
 require "much-not-given/version"
+require "much-plugin"
 
 module MuchNotGiven
+  include MuchPlugin
+
+  plugin_class_methods do
+    def not_given
+      @not_given ||=
+        begin
+          Class.new {
+            def initialize(receiver_name)
+              @receiver_name = receiver_name
+            end
+
+            def blank?
+              true
+            end
+
+            def present?
+              false
+            end
+
+            def to_s
+              "#{@receiver_name}.not_given"
+            end
+
+            def inspect
+              to_s
+            end
+
+            def ==(other)
+              if other.is_a?(self.class)
+                true
+              else
+                super
+              end
+            end
+          }.new(self.inspect)
+        end
+    end
+
+    def not_given?(value)
+      value == not_given
+    end
+
+    def given?(value)
+      value != not_given
+    end
+  end
 end

--- a/much-not-given.gemspec
+++ b/much-not-given.gemspec
@@ -21,4 +21,6 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = "~> 2.5"
 
   gem.add_development_dependency("assert", ["~> 2.18.4"])
+
+  gem.add_dependency("much-plugin", ["~> 0.2.2"])
 end

--- a/test/unit/much-not-given_tests.rb
+++ b/test/unit/much-not-given_tests.rb
@@ -1,0 +1,55 @@
+require "assert"
+require "much-not-given"
+
+module MuchNotGiven
+  class UnitTests < Assert::Context
+    desc "MuchNotGiven"
+    subject { unit_module }
+
+    let(:unit_module) { MuchNotGiven }
+
+    should "inlcude MuchPlugin" do
+      assert_that(unit_module).includes(MuchPlugin)
+    end
+  end
+
+  class ReceiverTests < UnitTests
+    desc "reciver"
+    subject { receiver_class }
+
+    let(:receiver_class) {
+      Class.new do
+        include MuchNotGiven
+      end
+    }
+
+    let(:value1) {
+      Factory.public_send(
+        [:integer, :string, :float, :data, :time, :path, :boolean].sample
+      )
+    }
+
+    should have_imeths :not_given, :not_given?, :given?
+
+    should "have a not_given singleton value" do
+      not_given = subject.not_given
+
+      assert_that(not_given.blank?).is_true
+      assert_that(not_given.present?).is_false
+      assert_that(not_given.to_s).equals("#{subject.inspect}.not_given")
+      assert_that(not_given.inspect).equals(not_given.to_s)
+
+      assert_that(subject.not_given).is_the_same_as(not_given)
+      assert_that(subject.not_given == not_given).is_true
+      assert_that(value1 == not_given).is_false
+    end
+
+    should "know if values are given or not" do
+      assert_that(subject.given?(value1)).is_true
+      assert_that(subject.given?(subject.not_given)).is_false
+
+      assert_that(subject.not_given?(value1)).is_false
+      assert_that(subject.not_given?(subject.not_given)).is_true
+    end
+  end
+end


### PR DESCRIPTION
This adds the MuchPlugin mix-in that provides the not-given API on
arbitrary receivers. I also added a first-pass generic README with
usage instructions.